### PR TITLE
Use try/catch and throws within processors to pass errors

### DIFF
--- a/fx/drop.js
+++ b/fx/drop.js
@@ -2,6 +2,8 @@ module.exports = fx;
 
 function fx(layer, options) {
     var limit = options.limit || 50;
+    if (isNaN(limit)) throw new Error('options.limit must be a number');
+
     if (layer.features.length > limit) {
         layer.features = layer.features.slice(0,limit);
     }

--- a/index.js
+++ b/index.js
@@ -26,15 +26,19 @@ function vtfx(data, options, callback) {
     var changed = false;
     var vt = mvt.tile.decode(data);
 
-    for (var i = 0; i < vt.layers.length; i++) {
-        var name = vt.layers[i].name;
-        if (!Array.isArray(options[name])) continue;
-        for (var j = 0; j < options[name].length; j++) {
-            var fxopts = options[name][j];
-            if (!module.processors[fxopts.id]) continue;
-            vt.layers[i] = module.processors[fxopts.id](vt.layers[i], fxopts);
-            changed = true;
+    try {
+        for (var i = 0; i < vt.layers.length; i++) {
+            var name = vt.layers[i].name;
+            if (!Array.isArray(options[name])) continue;
+            for (var j = 0; j < options[name].length; j++) {
+                var fxopts = options[name][j];
+                if (!module.processors[fxopts.id]) continue;
+                vt.layers[i] = module.processors[fxopts.id](vt.layers[i], fxopts);
+                changed = true;
+            }
         }
+    } catch(err) {
+        return callback(err);
     }
 
     callback(null, changed ? mvt.tile.encode(vt) : data);

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,13 @@ tape('drop', function(t) {
     });
 });
 
+tape('drop err', function(t) {
+    vtfx(beforepbf, {'poi_label':[{id:'drop', limit:'asdf'}]}, function(err, afterpbf) {
+        t.equal(err.toString(), 'Error: options.limit must be a number');
+        t.end();
+    });
+});
+
 tape('labelgrid', function(t) {
     vtfx(beforepbf, {'poi_label':[{id:'labelgrid', size:1024, order: 'scalerank', sort: 0}]}, function(err, afterpbf) {
         pbfEqual(afterpbf, __dirname + '/after-labelgrid-poi_label.pbf', t);


### PR DESCRIPTION
@ian29 added try/catch to the processor runner so you can just throw errors instead of logging them to the console. Example in drop processor.
